### PR TITLE
GitHub actions dockherhub test

### DIFF
--- a/.github/jobs/build/debian/Dockerfile.base
+++ b/.github/jobs/build/debian/Dockerfile.base
@@ -1,0 +1,31 @@
+FROM    debian@sha256:903779f30a7ee46937bfb21406f125d5fdace4178074e1cc71c49039ebf7f48f
+RUN     apt-get update && \
+        apt-get install -y build-essential \
+                           pkg-config \
+                           libc6-dev \
+                           m4 \
+                           g++-multilib \
+                           autoconf \
+                           libtool \
+                           ncurses-dev \
+                           unzip \
+                           git \
+                           python3 \
+                           python3-pip \
+                           zlib1g-dev \
+                           wget \
+                           curl \
+                           bsdmainutils \
+                           automake \
+                           vim \
+                           psmisc \
+                           apt-file \
+                           netcat
+RUN     pip3 install pyblake2 pyzmq pyutil python-qpid-proton simplejson
+RUN     git clone https://github.com/zcash/zcash.git
+WORKDIR /zcash
+RUN     git remote add gtd https://github.com/garethtdavies/zcash.git && git fetch --all && \
+        git checkout -B 3802_squashed gtd/3802_squashed
+RUN     ./zcutil/fetch-params.sh --testnet
+RUN     ./zcutil/build.sh -j$(nproc)
+RUN     mkdir /root/.zcash/ && touch /root/.zcash/zcash.conf

--- a/.github/jobs/build/debian/Dockerfile.newcommit
+++ b/.github/jobs/build/debian/Dockerfile.newcommit
@@ -1,2 +1,0 @@
-FROM    ==FROMIMAGE==
-RUN     git pull --verbose master:master && make -j$(nproc)

--- a/.github/jobs/build/debian/Dockerfile.newcommit
+++ b/.github/jobs/build/debian/Dockerfile.newcommit
@@ -1,0 +1,2 @@
+FROM    ==FROMIMAGE==
+RUN     git pull --verbose master:master && make -j$(nproc)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,18 +9,11 @@ jobs:
     runs-on: ubuntu-16.04
     
     steps:
-    - uses: actions/checkout@v1
-    - name: install-dependencies
-      run: |
-        sudo apt-get update -y
-        sudo apt-get install build-essential pkg-config libc6-dev m4 g++-multilib autoconf libtool ncurses-dev unzip git python3 python3-zmq zlib1g-dev wget curl bsdmainutils automake python3-pip python3-setuptools -y
-        sudo pip3 install pyflakes pyblake2 pyzmq pyutil python-qpid-proton simplejson
+    - uses: docker://zingolabs/zcashdebian:87c1df780db87a9b8d44ea7b0d1a30ee4f47f352
     #- name: pyflakes
     #  run: pyflakes qa src zcutil        
     - name: build
-      run: ./zcutil/build.sh -j$(nproc)
-    - name: fetch-params
-      run: ./zcutil/fetch-params.sh
+      run: ./make
     - name: list-stages
       run: ./qa/zcash/full_test_suite.py --list-stages
     - name: btest


### PR DESCRIPTION
Hi @garethtdavies .   No worries if you don't want to accept this.   It may well not work due to the lack fo an [actions.yml](https://help.github.com/en/articles/metadata-syntax-for-github-actions).   My thought is that it will be interesting to see how it fails.

What this includes:
  The Dockerfile that, `zingolabs/zcashdebian:87c1df780db87a9b8d44ea7b0d1a30ee4f47f352` was built from.

  A few deletions from the main events file.

  As you can see all dependency installation, parameter-fetching, and building (initial i.e. `zcutil/build.sh`) is moved into the Dockerfile.  For now that's built locally, though it obviously needs to be automated as its own workflow with appropriate trigger.

There're a few things in the Dockerfile that aren't necessary `vim`, `psmisc`, etc.  They can be excised.

  Anywho, hopefully this'll be interesting enough to provoke feedback from you.

  Oh, I manually tested that I could `docker pull` the image from a logged out machine that was remote to the machine where I built, so basic publication from dockerhub appears to work.
